### PR TITLE
fix: adjust s3 object format

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -X POST http://localhost:8080/crawl/ministerio_saude_brasil
 A operação acima irá baixar os dados do Ministério da Saúde e guardar em um bucket S3. A resposta segue o formato abaixo:
 
 ```
-{ "path": "2006-01-02/15_04/rawData.json"}
+{ "path": "ministerio_saude_brasil/2006-01-02/15_04/rawData.json"}
 ```
 
 ## Compilando

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -X POST http://localhost:8080/crawl/ministerio_saude_brasil
 A operação acima irá baixar os dados do Ministério da Saúde e guardar em um bucket S3. A resposta segue o formato abaixo:
 
 ```
-{ "path": "ministerio_saude_brasil/2006-01-02/15_04/rawData.json"}
+{ "path": "ministerio_saude_brasil/2006-01-02/15-04/rawData.json"}
 ```
 
 ## Compilando

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -79,7 +79,8 @@ func ComputeObjectName(source string, crawlDate time.Time, format string) (strin
 	if !validFormat(format) {
 		return "", errors.New("invalid format. please use json")
 	}
-	return fmt.Sprintf("%s/%s/rawData.%s.%s", source, crawlDate.Format("2006-01-02"), crawlDate.Format("15_04"), format), nil
+	// INFO: formato deve ser <source>/<ano-mes-dia>/<hora-minuto>/rawData.<formato>
+	return fmt.Sprintf("%s/%s/%s/rawData.%s", source, crawlDate.Format("2006-01-02"), crawlDate.Format("15-04"), format), nil
 }
 
 func validSource(source string) bool {


### PR DESCRIPTION
Não sei se o pessoal já está dependendo do formato anterior, mas acredito que seja melhor colocar o par *hora-minuto*  antes do arquivo para manter os objects ordenados alfabeticamente.

Isso vai simplificar operações de range-scan (batch reads)