### PR TITLE
fix: the overall software is not ready for HA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: covid0-backend
     build: .
     deploy:
-      replicas: 2
+      replicas: 1
     environment:
       COVID0_TEMP_BUCKET:
       AWS_ACCESS_KEY_ID:


### PR DESCRIPTION
O código atualmente não implementa locks para obter um recurso compartilhado (no caso o bucket da S3 e o acesso ao server do ministério da saúde.

Deixar o deploy com 2 pode dar a impressão errada do que o software suporta HA de um modo previsível.