### PR TITLE
fix: make tests more stable

### DIFF
--- a/datasources/format.go
+++ b/datasources/format.go
@@ -1,0 +1,42 @@
+package datasources
+
+type (
+	Format interface {
+		// Ext retorna a extensão do arquivo
+		Ext() string
+
+		// ContentType retorna o mime-type (sem informação de codificação)
+		ContentType() string
+
+		// String implements Stringer interface
+		String() string
+	}
+
+	format string
+)
+
+const (
+	JSON = format("json")
+)
+
+func (f format) Ext() string {
+	switch f {
+	case JSON:
+		return "json"
+	default:
+		panic("invalid format")
+	}
+}
+
+func (f format) ContentType() string {
+	switch f {
+	case JSON:
+		return "application/json"
+	default:
+		panic("invalid format")
+	}
+}
+
+func (f format) String() string {
+	return string(f)
+}

--- a/datasources/ivis.go
+++ b/datasources/ivis.go
@@ -1,0 +1,85 @@
+package datasources
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type (
+	// IVISDataset é um datasource OnDemand que retorna os dados do ministério da saúde
+	IVISDataset struct {
+		// Endpoint contém a url para ser acionada, por padrão utiliza
+		// http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js
+		endpoint string
+	}
+)
+
+const (
+	IVISDatasetDefaultURL = "http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js"
+)
+
+var (
+	defaultIVIS = &IVISDataset{}
+)
+
+// Name identificar o dataset
+func (i *IVISDataset) Name() string { return "ministerio_saude_brasil" }
+
+// Format retorna o formato no qual os dados são coletados
+func (i *IVISDataset) Format() Format {
+	return JSON
+}
+
+// Encoding retorna a codificação dos dados
+func (i *IVISDataset) Encoding() string {
+	// TODO: checar se essa codificação está correta
+	return "iso-8859-1"
+}
+
+// Collect aciona o serviço e roda uma coleta
+func (i *IVISDataset) Collect(_ time.Time) ([]byte, error) {
+	// TODO: gerar os logs aqui é incorreto pois isso é responsabilidade de quem chamou, mas por hora serve
+	// TODO: checar se podemos trocar por https para garantir integridade dos dados
+	// TODO: atlerar o http client e incluir um timeout para proteger o nosso processo caso o servidor remoto esteja muito lento
+	url := i.endpoint
+	if url == "" {
+		url = IVISDatasetDefaultURL
+	}
+	response, err := http.Get(url)
+	if err != nil {
+		// TODO: 500 nesse caso não é o ideal mas por enquanto resolve
+		log.Error().Err(err).Str("module", "datasource").Str("crawler", "IVISDataset").Msg("Error reaching source")
+		return nil, err
+	}
+	if response.StatusCode >= 400 {
+		log.Error().Err(errors.New(response.Status)).
+			Int("status", response.StatusCode).
+			Str("module", "datasource").
+			Str("crawler", "IVISDataset").
+			Msg("Unexpected status from source")
+		return nil, err
+	}
+	response.Close = true
+	defer response.Body.Close()
+
+	// TODO vetor de ataque em potencial, pois não existe limite no tamanho do buffer que vai ficar em memória (melhorar isso)
+	buf, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(errors.New(response.Status)).
+			Int("status", response.StatusCode).
+			Str("module", "datasource").
+			Str("crawler", "IVISDataset").
+			Msg("Unable to read response body")
+		return nil, err
+	}
+
+	if bytes.HasPrefix(buf, []byte("var database=")) {
+		buf = buf[len("var database="):]
+	}
+	return buf, nil
+}

--- a/datasources/ondemand.go
+++ b/datasources/ondemand.go
@@ -1,0 +1,17 @@
+package datasources
+
+import "errors"
+
+var (
+	errMissingDatasource = errors.New("datasource name is not valid")
+)
+
+// GetOnDemand retorna o datasorce identificado pelo nome ou um erro caso o nome seja inválido
+func GetOnDemand(name string) (OnDemand, error) {
+	// TODO: pensar em uma forma de registrar os datasources, por hora isso arquivo resolve
+	switch name {
+	case "ministerio_saude_brasil":
+		return &IVISDataset{}, nil
+	}
+	return nil, errMissingDatasource
+}

--- a/datasources/source.go
+++ b/datasources/source.go
@@ -1,0 +1,21 @@
+package datasources
+
+import "time"
+
+type (
+	// OnDemand indica data sources que retornam os dados em batches, normalmente não são atualizados com grande
+	// frequencia e portanto não são coletados com frequência
+	OnDemand interface {
+		// Name indica o nome do datasource, deve ser um identificador válido (aka letras/números/sem espaços)
+		Name() string
+
+		// Format retorna o formato no qual os dados são gravados
+		Format() Format
+
+		// Encoding retorna a codificação usada pelos dados
+		Encoding() string
+
+		// Collect executa uma coleta de dados e retorna quando a coleta estiver concluída
+		Collect(time.Time) ([]byte, error)
+	}
+)

--- a/scripts/test/bucketcreated/main.go
+++ b/scripts/test/bucketcreated/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"time"
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"gocloud.dev/blob"
+
+	// suporte apenas para s3 por enquanto
+	_ "gocloud.dev/blob/s3blob"
+)
+
+func main() {
+	addr := flag.String("a", "", "bucket url")
+	delay := flag.Duration("d", time.Second*10, "Time to wait between connection attempts")
+	attempts := flag.Int("c", 10, "How many attempts before abort")
+	flag.Parse()
+
+	if len(*addr) == 0 {
+		log.Fatal().Msg("Missing addr value")
+	}
+
+	if *attempts <= 0 {
+		log.Error().Msg("Cannot use negative attempts, will default to 1")
+		*attempts = 1
+	}
+
+	log.Info().Str("addr", *addr).Dur("delay", *delay).Int("attempts", *attempts).Send()
+
+	sleep := func(err error) {
+		log.Error().Err(err).Send()
+		time.Sleep(*delay)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < *attempts; i++ {
+		bucket, err := blob.OpenBucket(ctx, *addr)
+		if err != nil {
+			sleep(err)
+			continue
+		}
+		err = createFile(ctx, bucket, "random_object")
+		if err != nil {
+			sleep(err)
+			continue
+		}
+		bucket.Delete(ctx, "random_object")
+		bucket.Close()
+		log.Info().Str("addr", *addr).Dur("delay", *delay).Int("attempts", i+1).Msg("Success")
+		return
+	}
+	os.Exit(2)
+}
+
+func createFile(ctx context.Context, bucket *blob.Bucket, key string) error {
+	return bucket.WriteAll(ctx, key, []byte("hello"), &blob.WriterOptions{})
+}

--- a/scripts/test/integration_test/test.sh
+++ b/scripts/test/integration_test/test.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 readonly initialFolder=$(pwd)
 readonly composeFolder="${initialFolder}/test-compose/"
 
+export COVID0_TEMP_BUCKET='s3://mybucket?region=some&endpoint=localhost:4572&disableSSL=true&s3ForcePathStyle=true'
+export AWS_ACCESS_KEY_ID='keyid'
+export AWS_SECRET_ACCESS_KEY='keyval'
+
 function docker-compose-down {
     cd "${composeFolder}"
     docker-compose down
@@ -20,14 +24,12 @@ function docker-compose-up {
 
 function go-test {
     cd "${initialFolder}"
-    export COVID0_TEMP_BUCKET='s3://mybucket?region=some&endpoint=localhost:4572&disableSSL=true&s3ForcePathStyle=true'
-    export AWS_ACCESS_KEY_ID='keyid'
-    export AWS_SECRET_ACCESS_KEY='keyval'
     go test ./...
 }
 
 function wait-for-localstack {
     go run "${initialFolder}/scripts/test/waitfor/main.go" -a "localhost:4572"
+    go run "${initialFolder}/scripts/test/bucketcreated/main.go" -a "${COVID0_TEMP_BUCKET}"
 }
 
 trap 'docker-compose-down' EXIT

--- a/server/crawl.go
+++ b/server/crawl.go
@@ -1,12 +1,10 @@
 package server
 
 import (
-	"bytes"
-	"errors"
-	"io/ioutil"
 	"net/http"
 	"time"
 
+	"github.com/CovidZero/bino/datasources"
 	"github.com/CovidZero/bino/storage"
 	"github.com/rs/zerolog/log"
 )
@@ -14,43 +12,26 @@ import (
 type (
 	// Crawl expões as operações de baixar e guardar arquivos em um storage temporário
 	Crawl struct {
-		temp storage.Temp
+		source datasources.OnDemand
+		temp   storage.Temp
 	}
 )
 
 // FetchData inicia um novo processo de coleta (caso exista necessidade), caso contrário,
-// retorna a última coleta feita
+// retorna a última coleta feita.
 func (c *Crawl) FetchData(w http.ResponseWriter, req *http.Request) {
-	// TODO: checar se podemos trocar por https para garantir integridade dos dados
-	response, err := http.Get("http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js")
+	now := time.Now().UTC().Truncate(time.Minute)
+	buf, err := c.source.Collect(now)
 	if err != nil {
-		// TODO: 500 nesse caso não é o ideal mas por enquanto resolve
-		log.Error().Err(err).Str("module", "crawl").Msg("Error reaching source")
-		http.Error(w, "Unable to download content", http.StatusInternalServerError)
-		return
-	}
-	if response.StatusCode >= 400 {
-		log.Error().Err(errors.New(response.Status)).Int("status", response.StatusCode).Str("module", "crawl").Msg("Unexpected status from source")
-		http.Error(w, "Unable to download content. Server returned unexpected status", http.StatusInternalServerError)
-		return
-	}
-	response.Close = true
-	defer response.Body.Close()
-	// TODO vetor de ataque em potencial, pois não existe limite no tamanho do buffer que vai ficar em memória (melhorar isso)
-	buf, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		log.Error().Err(err).Str("module", "crawl").Msg("Error reading response body")
-		http.Error(w, "Unable to download content. Server returned unexpected status", http.StatusInternalServerError)
+		log.Error().Err(err).Str("module", "crawl").Str("source", c.source.Name()).Msg("Error reading data from source")
+		http.Error(w, "Unexpected error. Try again later", http.StatusBadGateway)
 		return
 	}
 
-	if bytes.HasPrefix(buf, []byte("var database=")) {
-		buf = buf[len("var database="):]
-	}
-
-	name, err := c.temp.StoreCrawl(req.Context(), "ministerio_saude_brasil", time.Now().UTC(), "json", buf)
+	name, err := c.temp.StoreCrawl(req.Context(), "ministerio_saude_brasil", now, c.source.Format().Ext(), buf)
 	if err != nil {
 		log.Error().Err(err).Str("module", "crawl").Msg("Unable to send data to temporary db")
+		http.Error(w, "Unexpected error. Try again later", http.StatusBadGateway)
 		return
 	}
 	respondWithJSON(w, req, struct {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -69,10 +69,6 @@ func (s *S3Storage) StoreCrawl(ctx context.Context, source string, crawlDate tim
 
 // ComputeObjectName retorna o nome de um objeto na S3 que identifica uma coleta
 func ComputeObjectName(source string, crawlDate time.Time, format string) (string, error) {
-	if !validSource(source) {
-		return "", errors.New("invalid source. please try again")
-	}
-
 	if !validCrawlDate(crawlDate) {
 		return "", errors.New("invalid crawl data. precision is limited to the minute")
 	}
@@ -82,10 +78,6 @@ func ComputeObjectName(source string, crawlDate time.Time, format string) (strin
 	}
 	// INFO: formato deve ser <source>/<ano-mes-dia>/<hora-minuto>/rawData.<formato>
 	return fmt.Sprintf("%s/%s/%s/rawData.%s", source, crawlDate.Format("2006-01-02"), crawlDate.Format("15-04"), format), nil
-}
-
-func validSource(source string) bool {
-	return source == "ministerio_saude_brasil"
 }
 
 func validCrawlDate(crawlDate time.Time) bool {


### PR DESCRIPTION
Permite que diferentes datasources sejam configurados o que permite que outros serviços possam acessar diferentes fontes de dados de maneira mais uniforme.

Isso também unifica a maneira como podemos proteger as origens de dados.

Além disso, ao enviar tudo para buckets S3, o sistema unifica a interface que os processos de downstream iram baixar os dados.