### PR TITLE
feature: interface to unify on-demand crawlers

### DIFF
--- a/Datasources.md
+++ b/Datasources.md
@@ -1,0 +1,7 @@
+# Lista de Datasources
+
+## IVIS
+
+__TODO__ melhorar essa descrição
+
+Fonte de dados do Ministério da Saúde do Brasil. Atualmente offline

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: build tidy test package watch devsetup test run precommit setupprecommit setupmodd
+.PHONY: build tidy test package watch devsetup test run precommit setupprecommit setupmodd testscompile
 
 build:
 	go build ./...
 
-test: build
+# apenas checando se os tests compilam, pois como rodamos todos os testes o tempo todo
+# esperar todo o ambiente de teste ser carregado para depois receber erros de compilação
+testscompile:
+	go test -run='^$$' ./...
+
+test: build testscompile
 	bash scripts/test/integration_test/test.sh
 
 tidy: test

--- a/README.md
+++ b/README.md
@@ -51,4 +51,24 @@ Empacote a aplicação usando docker como descrito acima e execute o seguinte co
 docker run -p '8080:8080' -e COVID0_TEMP_BUCKET -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY covidzero/bino:latest
 ```
 
-Para fins de teste, você pode usar o atalho `make run`
+Para rodar local, você pode usar o atalho `make run`
+
+## Criando um novo datasource - OnDemand
+
+Datasources `on-demand` são acionados via chamada URL e devem obter os dados a cada vez que são executados. Lembre-se
+que por enquanto não existe proteção para impedir que ocorra exaustão de recursos externos. Sendo assim, verifique
+a frequência que o endpoint será chamado e se é compatível com a capacidade do datasource que você irá incluir.
+
+O formato dos dados não é importante, `bino` opera com dados bytes e o processamento feito deve ser o mínimo possível,
+normalmente remover alguns sufixos ou prefixos.
+
+Com isso em mente, vamos aos passos que devem ser feitos para incluir um novo Datasource HTTP.
+
+- Na pasta `datasources` crie um arquivo `nome_do_meu_datasource.go` (tente usar nomes curtos).
+- No arquivo `nome_do_meu_datasource.go` escreva o seu coletor (use `ivis.go` como exemplo)
+- No arquivo `ondemand.go` altere as funções para `AllOnDemand` e `GetOnDemand` para expor o seu datasource
+- Se os dados do seu datasource não são JSON, adicione o formato novo em `format.go`
+- Na pasta `server` escreva um teste de integração para o seu datasource (use `crawl_ivis_test.go` como exemplo)
+- Evite criar muitos mocks, Go é uma linguagem compilada e mocks em encesso não são a melhor maneira de trabalhar.
+- Descreva em [Datasources.md](Datasources.md) o seu datasource.
+- Be Happy e fique em casa! Sério... Fique em casa! :-)

--- a/datasources/format.go
+++ b/datasources/format.go
@@ -1,0 +1,42 @@
+package datasources
+
+type (
+	Format interface {
+		// Ext retorna a extensão do arquivo
+		Ext() string
+
+		// ContentType retorna o mime-type (sem informação de codificação)
+		ContentType() string
+
+		// String implements Stringer interface
+		String() string
+	}
+
+	format string
+)
+
+const (
+	JSON = format("json")
+)
+
+func (f format) Ext() string {
+	switch f {
+	case JSON:
+		return "json"
+	default:
+		panic("invalid format")
+	}
+}
+
+func (f format) ContentType() string {
+	switch f {
+	case JSON:
+		return "application/json"
+	default:
+		panic("invalid format")
+	}
+}
+
+func (f format) String() string {
+	return string(f)
+}

--- a/datasources/ivis.go
+++ b/datasources/ivis.go
@@ -1,0 +1,85 @@
+package datasources
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type (
+	// IVISDataset é um datasource OnDemand que retorna os dados do ministério da saúde
+	IVISDataset struct {
+		// Endpoint contém a url para ser acionada, por padrão utiliza
+		// http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js
+		endpoint string
+	}
+)
+
+const (
+	IVISDatasetDefaultURL = "http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js"
+)
+
+var (
+	defaultIVIS = &IVISDataset{}
+)
+
+// Name identificar o dataset
+func (i *IVISDataset) Name() string { return "ministerio_saude_brasil" }
+
+// Format retorna o formato no qual os dados são coletados
+func (i *IVISDataset) Format() Format {
+	return JSON
+}
+
+// Encoding retorna a codificação dos dados
+func (i *IVISDataset) Encoding() string {
+	// TODO: checar se essa codificação está correta
+	return "iso-8859-1"
+}
+
+// Collect aciona o serviço e roda uma coleta
+func (i *IVISDataset) Collect(_ time.Time) ([]byte, error) {
+	// TODO: gerar os logs aqui é incorreto pois isso é responsabilidade de quem chamou, mas por hora serve
+	// TODO: checar se podemos trocar por https para garantir integridade dos dados
+	// TODO: atlerar o http client e incluir um timeout para proteger o nosso processo caso o servidor remoto esteja muito lento
+	url := i.endpoint
+	if url == "" {
+		url = IVISDatasetDefaultURL
+	}
+	response, err := http.Get(url)
+	if err != nil {
+		// TODO: 500 nesse caso não é o ideal mas por enquanto resolve
+		log.Error().Err(err).Str("module", "datasource").Str("crawler", "IVISDataset").Msg("Error reaching source")
+		return nil, err
+	}
+	if response.StatusCode >= 400 {
+		log.Error().Err(errors.New(response.Status)).
+			Int("status", response.StatusCode).
+			Str("module", "datasource").
+			Str("crawler", "IVISDataset").
+			Msg("Unexpected status from source")
+		return nil, err
+	}
+	response.Close = true
+	defer response.Body.Close()
+
+	// TODO vetor de ataque em potencial, pois não existe limite no tamanho do buffer que vai ficar em memória (melhorar isso)
+	buf, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(errors.New(response.Status)).
+			Int("status", response.StatusCode).
+			Str("module", "datasource").
+			Str("crawler", "IVISDataset").
+			Msg("Unable to read response body")
+		return nil, err
+	}
+
+	if bytes.HasPrefix(buf, []byte("var database=")) {
+		buf = buf[len("var database="):]
+	}
+	return buf, nil
+}

--- a/datasources/ivis.go
+++ b/datasources/ivis.go
@@ -20,7 +20,11 @@ type (
 )
 
 const (
+	// IVISDatasetDefaultURL é a URL padrão a ser utilizada caso a variável DATASOURCE_IVIS_URL não exista
 	IVISDatasetDefaultURL = "http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js"
+
+	// IVISDatasetname é o nome pelo qual o dataset será referenciado na S3
+	IVISDatasetName = "ministerio_saude_brasil"
 )
 
 var (
@@ -28,7 +32,7 @@ var (
 )
 
 // Name identificar o dataset
-func (i *IVISDataset) Name() string { return "ministerio_saude_brasil" }
+func (i *IVISDataset) Name() string { return IVISDatasetName }
 
 // Format retorna o formato no qual os dados são coletados
 func (i *IVISDataset) Format() Format {

--- a/datasources/ondemand.go
+++ b/datasources/ondemand.go
@@ -1,0 +1,17 @@
+package datasources
+
+import "errors"
+
+var (
+	errMissingDatasource = errors.New("datasource name is not valid")
+)
+
+// GetOnDemand retorna o datasorce identificado pelo nome ou um erro caso o nome seja inválido
+func GetOnDemand(name string) (OnDemand, error) {
+	// TODO: pensar em uma forma de registrar os datasources, por hora isso arquivo resolve
+	switch name {
+	case "ministerio_saude_brasil":
+		return &IVISDataset{}, nil
+	}
+	return nil, errMissingDatasource
+}

--- a/datasources/ondemand.go
+++ b/datasources/ondemand.go
@@ -1,6 +1,9 @@
 package datasources
 
-import "errors"
+import (
+	"errors"
+	"os"
+)
 
 var (
 	errMissingDatasource = errors.New("datasource name is not valid")
@@ -11,7 +14,9 @@ func GetOnDemand(name string) (OnDemand, error) {
 	// TODO: pensar em uma forma de registrar os datasources, por hora isso arquivo resolve
 	switch name {
 	case "ministerio_saude_brasil":
-		return &IVISDataset{}, nil
+		return &IVISDataset{
+			endpoint: os.Getenv("DATASOURCE_IVIS_URL"),
+		}, nil
 	}
 	return nil, errMissingDatasource
 }

--- a/datasources/ondemand.go
+++ b/datasources/ondemand.go
@@ -9,11 +9,18 @@ var (
 	errMissingDatasource = errors.New("datasource name is not valid")
 )
 
+// AllOnDemand retorna a lista de todos os coletores OnDemand disponíveis
+func AllOnDemand() []string {
+	return []string{
+		IVISDatasetName,
+	}
+}
+
 // GetOnDemand retorna o datasorce identificado pelo nome ou um erro caso o nome seja inválido
 func GetOnDemand(name string) (OnDemand, error) {
 	// TODO: pensar em uma forma de registrar os datasources, por hora isso arquivo resolve
 	switch name {
-	case "ministerio_saude_brasil":
+	case IVISDatasetName:
 		return &IVISDataset{
 			endpoint: os.Getenv("DATASOURCE_IVIS_URL"),
 		}, nil

--- a/datasources/source.go
+++ b/datasources/source.go
@@ -1,0 +1,21 @@
+package datasources
+
+import "time"
+
+type (
+	// OnDemand indica data sources que retornam os dados em batches, normalmente não são atualizados com grande
+	// frequencia e portanto não são coletados com frequência
+	OnDemand interface {
+		// Name indica o nome do datasource, deve ser um identificador válido (aka letras/números/sem espaços)
+		Name() string
+
+		// Format retorna o formato no qual os dados são gravados
+		Format() Format
+
+		// Encoding retorna a codificação usada pelos dados
+		Encoding() string
+
+		// Collect executa uma coleta de dados e retorna quando a coleta estiver concluída
+		Collect(time.Time) ([]byte, error)
+	}
+)

--- a/internal/testutil/changeenv.go
+++ b/internal/testutil/changeenv.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "os"
+
+// ChangeEnv muda o valor da variável de ambiente name para nval e retorna uma funcão
+// que quando acionada altera o valor de volta para o original
+func ChangeEnv(name string, nval string) func() {
+	oldv := os.Getenv(name)
+	os.Setenv(name, nval)
+	return func() {
+		os.Setenv(name, oldv)
+	}
+}

--- a/internal/testutil/post.go
+++ b/internal/testutil/post.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+// POSTRaw executa uma chamada HTTP post na URL informada com o body e contentType informados.
+//
+// Caso uma resposta seja obtida, o conteúdo é lido para memória e depois enviado para a função
+// codec que deve transformar os bytes recebidos e guardar em out
+func POSTRaw(t *testing.T, url string, contentType string, body io.Reader, out interface{}, codec func([]byte, interface{}) error) int {
+	res, err := http.Post(url, contentType, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = codec(data, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.StatusCode
+}

--- a/internal/testutil/servefile.go
+++ b/internal/testutil/servefile.go
@@ -1,0 +1,15 @@
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// ServeFile retorna um server http que sempre retorna o conteudo ignorando o caminho
+func ServeFile(content []byte) *httptest.Server {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(content)
+	}))
+	return s
+}

--- a/internal/testutil/tempdb.go
+++ b/internal/testutil/tempdb.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/CovidZero/bino/storage"
+	"gocloud.dev/blob"
+)
+
+// TempDB abre uma conexão com o banco de dados temporário.
+//
+// Note que o sistema presume que estará rodando da mesma forma que a aplicação roda,
+// isso implica que você deve fornecer um servidor compatível com S3 e configurar a variável
+// de ambiente COVID0_TEMP_BUCKET
+func TempDB(ctx context.Context, t *testing.T) (storage.Temp, func(context.Context, *testing.T, string) []byte) {
+	db, err := storage.TempDB(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucket, err := blob.OpenBucket(ctx, os.Getenv("COVID0_TEMP_BUCKET"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	getfn := func(ctx context.Context, t *testing.T, key string) []byte {
+		value, err := bucket.ReadAll(ctx, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return value
+	}
+	return db, getfn
+}

--- a/scripts/test/bucketcreated/main.go
+++ b/scripts/test/bucketcreated/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"time"
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"gocloud.dev/blob"
+
+	// suporte apenas para s3 por enquanto
+	_ "gocloud.dev/blob/s3blob"
+)
+
+func main() {
+	addr := flag.String("a", "", "bucket url")
+	delay := flag.Duration("d", time.Second*10, "Time to wait between connection attempts")
+	attempts := flag.Int("c", 10, "How many attempts before abort")
+	flag.Parse()
+
+	if len(*addr) == 0 {
+		log.Fatal().Msg("Missing addr value")
+	}
+
+	if *attempts <= 0 {
+		log.Error().Msg("Cannot use negative attempts, will default to 1")
+		*attempts = 1
+	}
+
+	log.Info().Str("addr", *addr).Dur("delay", *delay).Int("attempts", *attempts).Send()
+
+	sleep := func(err error) {
+		log.Error().Err(err).Send()
+		time.Sleep(*delay)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < *attempts; i++ {
+		bucket, err := blob.OpenBucket(ctx, *addr)
+		if err != nil {
+			sleep(err)
+			continue
+		}
+		err = createFile(ctx, bucket, "random_object")
+		if err != nil {
+			sleep(err)
+			continue
+		}
+		bucket.Delete(ctx, "random_object")
+		bucket.Close()
+		log.Info().Str("addr", *addr).Dur("delay", *delay).Int("attempts", i+1).Msg("Success")
+		return
+	}
+	os.Exit(2)
+}
+
+func createFile(ctx context.Context, bucket *blob.Bucket, key string) error {
+	return bucket.WriteAll(ctx, key, []byte("hello"), &blob.WriterOptions{})
+}

--- a/scripts/test/bucketcreated/main.go
+++ b/scripts/test/bucketcreated/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"time"
-	"context"
 
 	"github.com/rs/zerolog/log"
 

--- a/scripts/test/integration_test/test.sh
+++ b/scripts/test/integration_test/test.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 readonly initialFolder=$(pwd)
 readonly composeFolder="${initialFolder}/test-compose/"
 
+export COVID0_TEMP_BUCKET='s3://mybucket?region=some&endpoint=localhost:4572&disableSSL=true&s3ForcePathStyle=true'
+export AWS_ACCESS_KEY_ID='keyid'
+export AWS_SECRET_ACCESS_KEY='keyval'
+
 function docker-compose-down {
     cd "${composeFolder}"
     docker-compose down
@@ -20,14 +24,12 @@ function docker-compose-up {
 
 function go-test {
     cd "${initialFolder}"
-    export COVID0_TEMP_BUCKET='s3://mybucket?region=some&endpoint=localhost:4572&disableSSL=true&s3ForcePathStyle=true'
-    export AWS_ACCESS_KEY_ID='keyid'
-    export AWS_SECRET_ACCESS_KEY='keyval'
     go test ./...
 }
 
 function wait-for-localstack {
     go run "${initialFolder}/scripts/test/waitfor/main.go" -a "localhost:4572"
+    go run "${initialFolder}/scripts/test/bucketcreated/main.go" -a "${COVID0_TEMP_BUCKET}"
 }
 
 trap 'docker-compose-down' EXIT

--- a/scripts/test/integration_test/test.sh
+++ b/scripts/test/integration_test/test.sh
@@ -14,12 +14,12 @@ export AWS_SECRET_ACCESS_KEY='keyval'
 
 function docker-compose-down {
     cd "${composeFolder}"
-    docker-compose down
+    #docker-compose down
 }
 
 function docker-compose-up {
     cd "${composeFolder}"
-    docker-compose up -d
+    #docker-compose up -d
 }
 
 function go-test {
@@ -28,8 +28,9 @@ function go-test {
 }
 
 function wait-for-localstack {
-    go run "${initialFolder}/scripts/test/waitfor/main.go" -a "localhost:4572"
-    go run "${initialFolder}/scripts/test/bucketcreated/main.go" -a "${COVID0_TEMP_BUCKET}"
+    #go run "${initialFolder}/scripts/test/waitfor/main.go" -a "localhost:4572"
+    #go run "${initialFolder}/scripts/test/bucketcreated/main.go" -a "${COVID0_TEMP_BUCKET}"
+    true
 }
 
 trap 'docker-compose-down' EXIT

--- a/server/crawl.go
+++ b/server/crawl.go
@@ -1,12 +1,10 @@
 package server
 
 import (
-	"bytes"
-	"errors"
-	"io/ioutil"
 	"net/http"
 	"time"
 
+	"github.com/CovidZero/bino/datasources"
 	"github.com/CovidZero/bino/storage"
 	"github.com/rs/zerolog/log"
 )
@@ -14,43 +12,26 @@ import (
 type (
 	// Crawl expões as operações de baixar e guardar arquivos em um storage temporário
 	Crawl struct {
-		temp storage.Temp
+		source datasources.OnDemand
+		temp   storage.Temp
 	}
 )
 
 // FetchData inicia um novo processo de coleta (caso exista necessidade), caso contrário,
-// retorna a última coleta feita
+// retorna a última coleta feita.
 func (c *Crawl) FetchData(w http.ResponseWriter, req *http.Request) {
-	// TODO: checar se podemos trocar por https para garantir integridade dos dados
-	response, err := http.Get("http://plataforma.saude.gov.br/novocoronavirus/resources/scripts/database.js")
+	now := time.Now().UTC().Truncate(time.Minute)
+	buf, err := c.source.Collect(now)
 	if err != nil {
-		// TODO: 500 nesse caso não é o ideal mas por enquanto resolve
-		log.Error().Err(err).Str("module", "crawl").Msg("Error reaching source")
-		http.Error(w, "Unable to download content", http.StatusInternalServerError)
-		return
-	}
-	if response.StatusCode >= 400 {
-		log.Error().Err(errors.New(response.Status)).Int("status", response.StatusCode).Str("module", "crawl").Msg("Unexpected status from source")
-		http.Error(w, "Unable to download content. Server returned unexpected status", http.StatusInternalServerError)
-		return
-	}
-	response.Close = true
-	defer response.Body.Close()
-	// TODO vetor de ataque em potencial, pois não existe limite no tamanho do buffer que vai ficar em memória (melhorar isso)
-	buf, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		log.Error().Err(err).Str("module", "crawl").Msg("Error reading response body")
-		http.Error(w, "Unable to download content. Server returned unexpected status", http.StatusInternalServerError)
+		log.Error().Err(err).Str("module", "crawl").Str("source", c.source.Name()).Msg("Error reading data from source")
+		http.Error(w, "Unexpected error. Try again later", http.StatusBadGateway)
 		return
 	}
 
-	if bytes.HasPrefix(buf, []byte("var database=")) {
-		buf = buf[len("var database="):]
-	}
-
-	name, err := c.temp.StoreCrawl(req.Context(), "ministerio_saude_brasil", time.Now().UTC(), "json", buf)
+	name, err := c.temp.StoreCrawl(req.Context(), "ministerio_saude_brasil", now, c.source.Format().Ext(), buf)
 	if err != nil {
 		log.Error().Err(err).Str("module", "crawl").Msg("Unable to send data to temporary db")
+		http.Error(w, "Unexpected error. Try again later", http.StatusBadGateway)
 		return
 	}
 	respondWithJSON(w, req, struct {

--- a/server/crawl_ivis_test.go
+++ b/server/crawl_ivis_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CovidZero/bino/datasources"
+	"github.com/CovidZero/bino/internal/testutil"
+)
+
+// TestIVISCrawl verifica se o processo para coletar os dados da base IVIS está funcionando como esperado
+func TestIVISCrawl(t *testing.T) {
+	ctx := context.TODO()
+
+	fakeContent := "{}"
+	ivisMockServer := testutil.ServeFile([]byte(fmt.Sprintf("var database=%v", fakeContent)))
+	defer ivisMockServer.Close()
+	defer testutil.ChangeEnv("DATASOURCE_IVIS_URL", ivisMockServer.URL)()
+	ivisSource, err := datasources.GetOnDemand("ministerio_saude_brasil")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, getContent := testutil.TempDB(ctx, t)
+
+	crawler := &Crawl{
+		source: ivisSource,
+		temp:   db,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(crawler.FetchData))
+	defer server.Close()
+	response := struct {
+		Path string `json:"path"`
+	}{}
+	status := testutil.POSTRaw(t, server.URL, "application/json", nil, &response, json.Unmarshal)
+	if status != http.StatusOK {
+		t.Fatalf("crawlers should always return 200 (at least for now...) but got %v", status)
+	}
+	t.Logf("Path: %v", response.Path)
+
+	actualContent := string(getContent(ctx, t, response.Path))
+	if actualContent != fakeContent {
+		t.Fatalf("Should have %v in s3 but got %v", fakeContent, actualContent)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -12,10 +12,18 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// NewAPI retorna um servidor HTTP pré-configurado que guarda as informações temporárias no storage informado
-func NewAPI(bindAddr string, storage storage.Temp) (*http.Server, error) {
+func allCollectors(storage storage.Temp) (http.Handler, error) {
 	r := mux.NewRouter()
 	err := setupDatasourcesRoutes(r, storage)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// NewAPI retorna um servidor HTTP pré-configurado que guarda as informações temporárias no storage informado
+func NewAPI(bindAddr string, storage storage.Temp) (*http.Server, error) {
+	collectors, err := allCollectors(storage)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +39,7 @@ func NewAPI(bindAddr string, storage storage.Temp) (*http.Server, error) {
 		WriteTimeout:   time.Second * 10,
 		MaxHeaderBytes: 1 * 1024 * 1024 * 1024,
 
-		Handler: r,
+		Handler: collectors,
 	}
 	return server, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -45,8 +45,13 @@ func NewAPI(bindAddr string, storage storage.Temp) (*http.Server, error) {
 }
 
 func setupDatasourcesRoutes(r *mux.Router, storage storage.Temp) error {
-	if err := registerCrawlEndpoint(r, storage, "ministerio_saude_brasil"); err != nil {
-		return err
+	names := datasources.AllOnDemand()
+	for _, name := range names {
+		if err := registerCrawlEndpoint(r, storage, name); err != nil {
+			log.Error().Err(err).Str("module", "setup-datasources").Str("datasourceName", name).Msg("Unable to configure datasource, will SKIP!!!!")
+		} else {
+			log.Info().Str("module", "setup-datasources").Str("datasourceName", name).Msg("Datasource available")
+		}
 	}
 	return nil
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -69,10 +69,6 @@ func (s *S3Storage) StoreCrawl(ctx context.Context, source string, crawlDate tim
 
 // ComputeObjectName retorna o nome de um objeto na S3 que identifica uma coleta
 func ComputeObjectName(source string, crawlDate time.Time, format string) (string, error) {
-	if !validSource(source) {
-		return "", errors.New("invalid source. please try again")
-	}
-
 	if !validCrawlDate(crawlDate) {
 		return "", errors.New("invalid crawl data. precision is limited to the minute")
 	}
@@ -82,10 +78,6 @@ func ComputeObjectName(source string, crawlDate time.Time, format string) (strin
 	}
 	// INFO: formato deve ser <source>/<ano-mes-dia>/<hora-minuto>/rawData.<formato>
 	return fmt.Sprintf("%s/%s/%s/rawData.%s", source, crawlDate.Format("2006-01-02"), crawlDate.Format("15-04"), format), nil
-}
-
-func validSource(source string) bool {
-	return source == "ministerio_saude_brasil"
 }
 
 func validCrawlDate(crawlDate time.Time) bool {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -73,9 +73,6 @@ func ComputeObjectName(source string, crawlDate time.Time, format string) (strin
 		return "", errors.New("invalid crawl data. precision is limited to the minute")
 	}
 
-	if !validFormat(format) {
-		return "", errors.New("invalid format. please use json")
-	}
 	// INFO: formato deve ser <source>/<ano-mes-dia>/<hora-minuto>/rawData.<formato>
 	return fmt.Sprintf("%s/%s/%s/rawData.%s", source, crawlDate.Format("2006-01-02"), crawlDate.Format("15-04"), format), nil
 }
@@ -83,8 +80,4 @@ func ComputeObjectName(source string, crawlDate time.Time, format string) (strin
 func validCrawlDate(crawlDate time.Time) bool {
 	name, _ := crawlDate.Zone()
 	return name == "UTC"
-}
-
-func validFormat(format string) bool {
-	return format == "json"
 }


### PR DESCRIPTION
Permite que diferentes datasources sejam configurados o que permite que outros serviços possam acessar diferentes fontes de dados de maneira mais uniforme.

Isso também unifica a maneira como podemos proteger as origens de dados.

Além disso, ao enviar tudo para buckets S3, o sistema unifica a interface que os processos de downstream iram baixar os dados.